### PR TITLE
[+] Remove deprecated nsIJSON. (Switched to JSON.)

### DIFF
--- a/src/components/ssl-observatory.js
+++ b/src/components/ssl-observatory.js
@@ -104,7 +104,7 @@ function SSLObservatory() {
   // and to protect against CSRF
   this.csrf_nonce = "#"+Math.random().toString()+Math.random().toString();
 
-  this.compatJSON = Cc["@mozilla.org/dom/json;1"].createInstance(Ci.nsIJSON);
+  this.compatJSON = Cc["@mozilla.org/dom/json;1"].createInstance(Ci.JSON);
 
   // Register observer
   OS.addObserver(this, "http-on-examine-response", false);


### PR DESCRIPTION
In the console, I kept seeing nsJSON was deprecated, and to use JSON. So this takes care of that, however I am unsure if this does not break anything. However I am currently using encryptedweb, and it seem to function as wanted. However please check to see if it works for you.